### PR TITLE
CORS origin reflection

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Ceres Imaging Tile Server",
   "type": "module",
   "scripts": {
-    "dev": "nodemon -e js,xml,json --inspect=0.0.0.0:9229 --expose-gc --experimental-modules --es-module-specifier-resolution=node server",
+    "dev": "npx nodemon -e js,xml,json --inspect=0.0.0.0:9229 --expose-gc --experimental-modules --es-module-specifier-resolution=node server",
     "start": "node --expose-gc --experimental-modules --es-module-specifier-resolution=node server",
     "test": "NODE_ENV=test node --expose-gc ./node_modules/.bin/jest",
     "test:watch": "npm run test --watch",

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ import custom from './routes/custom';
 const app = express();
 
 // Add CORS
-app.use(cors());
+app.use(cors({ origin: true }));
 
 // Add logger
 if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
Added `origin: true` to the Express CORS middleware, which is essentially a wildcard.

This is useful for many reasons, but particularly when tiles need to be loaded over XHR, which was the driving force for this change.

ceresimaging/avian#2052