### PR TITLE
Exclude is_staff markers for combo/issue images.

### DIFF
--- a/middlewares/marker.js
+++ b/middlewares/marker.js
@@ -20,9 +20,7 @@ const buildQuery = (imagery, flight, user, exclusive) => {
     } else {
       userFilter = `
         AND dwf.is_staff = false
-        AND (
-          dwf.is_private = false OR dwf.user_profile_id = '${user}'
-        )
+        AND dwf.user_profile_id = '${user}'
       `;
     }
   }
@@ -90,11 +88,10 @@ export const markerLayer = (req, res, next) => {
   const { flight, imagery } = req.params;
   const { user } = req.query;
   const { map } = res.locals;
-  let { exclusive = false } = req.query;
+  const { exclusive = false } = req.query;
 
   if (user === process.env.SUPPORT_USER) {
     map.fromStringSync(issueStyle);
-    exclusive = true;
   } else {
     map.fromStringSync(style);
   }


### PR DESCRIPTION
This excludes the is_staff markers from the images needed for the imagery notifications. An example should be this image:

https://tiles.ceresimaging.net/combo/issues/4ce90020-60a2-4bce-a383-b2e5a009e61c/541699cd-6c1b-4558-9a80-63f25d0fb8cc.png