### PR TITLE
Don't reference mapnik by file URL in package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM maurimiranda/node-mapnik-gdal:latest
+inkFROM maurimiranda/node-mapnik-gdal:latest
+
+RUN \
+  cd /src/node-mapnik && \
+  npm link
 
 WORKDIR /srv/tiler
 
 # Install Node packages
 COPY package.json package-lock.json ./
-RUN npm install
+RUN \
+  npm install && \
+  npm link mapnik
+
 
 # Copy code
 COPY . .

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cors": "^2.8.5",
     "express": "~4.16.4",
     "ioredis": "^4.17.3",
-    "mapnik": "file:/src/node-mapnik",
+    "mapnik": "^4.5.2",
     "morgan": "^1.9.1",
     "redlock": "^4.1.0",
     "sharp": "^0.25.4",


### PR DESCRIPTION
Instead, use `npm link` to link it to Mauri's full GDAL build in /src/node-mapnik.

Hey @maurimiranda ! This made it easier for me to do local dev on Mac, where I was able to install a working build with homebrew. Seems like a potentially useful change so pushing upstream in case it makes sense to you too.